### PR TITLE
Reduce Elixir version requirements to 1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Hammox.MixProject do
     [
       app: :hammox,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
There is no reason to require elixir 1.9 for this library. No 1.9 or higher code is written, and the highest requirement a lib has is 1.7 for the ex_doc.