### PR TITLE
Fix printing struct name mismatch error

### DIFF
--- a/lib/hammox/type_match_error.ex
+++ b/lib/hammox/type_match_error.ex
@@ -94,6 +94,12 @@ defmodule Hammox.TypeMatchError do
     "Expected the value to be #{Utils.module_to_string(expected_struct_name)} struct."
   end
 
+  defp human_reason({:struct_name_type_mismatch, actual_struct_name, expected_struct_name}) do
+    "Expected the value to be a #{Utils.module_to_string(expected_struct_name)}, got a #{
+      Utils.module_to_string(actual_struct_name)
+    }"
+  end
+
   defp human_reason({:module_fetch_failure, module_name}) do
     "Could not load module #{Utils.module_to_string(module_name)}."
   end

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -579,6 +579,10 @@ defmodule HammoxTest do
       assert_fail(:foo_struct_literal, %{foo: :bar})
     end
 
+    test "fail different struct" do
+      assert_fail(:foo_struct_literal, %Hammox.Test.OtherStruct{})
+    end
+
     test "pass default struct" do
       assert_pass(:foo_struct_literal, %Hammox.Test.Struct{})
     end

--- a/test/support/other_struct.ex
+++ b/test/support/other_struct.ex
@@ -1,0 +1,3 @@
+defmodule Hammox.Test.OtherStruct do
+  defstruct [:foo]
+end


### PR DESCRIPTION
Hammox uses the `struct_name_type_mismatch` error when it detects an incorrect struct being used compared to what was specified. As I understand, it is raised in two cases:

* when a map is passed where a struct is expected,
* when struct A is passed where struct B is expected.

The second case has an error associated, but there was no function formatting this error into a human-readable message.

This PR adds a missing test case and fixes the problem by formatting the message correctly.