### PR TITLE
fix multiline parametrized types

### DIFF
--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -672,8 +672,10 @@ defmodule Hammox.TypeEngine do
   end
 
   defp fill_type_var(type, var, arg) do
+    {:var, _, var_name} = var
+
     Utils.type_map(type, fn
-      ^var -> arg
+      {:var, _, ^var_name} -> arg
       other -> other
     end)
   end

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1157,6 +1157,12 @@ defmodule HammoxTest do
     end
   end
 
+  describe "multiline parametrized types" do
+    test "works when param usage is on a line other than declaration line" do
+      assert_pass(:foo_multiline_param_type, %{value: :arg})
+    end
+  end
+
   defp assert_pass(function_name, value) do
     TestMock |> expect(function_name, fn -> value end)
     assert value == apply(TestMock, function_name, [])

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -113,4 +113,9 @@ defmodule Hammox.Test.Behaviour do
   @type param_type_1(arg1) :: arg1
   @type param_type_2(arg2) :: param_type_1(arg2)
   @callback foo_nested_param_types() :: param_type_2(:param)
+
+  @type multiline_param_type(param) :: %{
+          value: param
+        }
+  @callback foo_multiline_param_type() :: multiline_param_type(:arg)
 end


### PR DESCRIPTION
Fixes #29.

There was a bug where during looking for the param name in the parametrized type definition to replace it with type arg, we were matching against the full syntax tuple of the original declaration of the param, including the line number information. This meant that if the definition of the parametrized type spanned multiple lines, the syntax tuple of the occurrence would be different from the original declaration tuple.

This changes the behaviour to only match the param name.