### PR TITLE
support all type kinds

### DIFF
--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1163,6 +1163,26 @@ defmodule HammoxTest do
     end
   end
 
+  describe "private types" do
+    test "pass" do
+      assert_pass(:foo_private_type, :private_value)
+    end
+
+    test "fail" do
+      assert_fail(:foo_private_type, :other)
+    end
+  end
+
+  describe "opaque types" do
+    test "pass" do
+      assert_pass(:foo_opaque_type, :opaque_value)
+    end
+
+    test "fail" do
+      assert_fail(:foo_opaque_type, :other)
+    end
+  end
+
   defp assert_pass(function_name, value) do
     TestMock |> expect(function_name, fn -> value end)
     assert value == apply(TestMock, function_name, [])

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -118,4 +118,11 @@ defmodule Hammox.Test.Behaviour do
           value: param
         }
   @callback foo_multiline_param_type() :: multiline_param_type(:arg)
+
+  @typep private_type :: :private_value
+  @type type_including_private_type :: private_type()
+  @callback foo_private_type() :: type_including_private_type()
+
+  @opaque opaque_type :: :opaque_value
+  @callback foo_opaque_type() :: opaque_type
 end


### PR DESCRIPTION
Fixes #41.

Hammox blows up when encountering `@typep` and `@opaque`. For now we will treat them like any other type.

Further work on opaque types in #43 