### PR TITLE
fix test compile warnings

### DIFF
--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -3,10 +3,7 @@ defmodule HammoxTest do
 
   import Hammox
 
-  setup_all do
-    defmock(TestMock, for: Hammox.Test.Behaviour)
-    :ok
-  end
+  defmock(TestMock, for: Hammox.Test.Behaviour)
 
   describe "protect/2" do
     test "returns function protected from contract errors" do


### PR DESCRIPTION
Sometimes the test compilation couldn't detect that the mock was being defined. This moves the definition of the mock to be part of the test module itself which alleviates the problem.