### PR TITLE
cache typespecs

### DIFF
--- a/lib/hammox/application.ex
+++ b/lib/hammox/application.ex
@@ -1,0 +1,8 @@
+defmodule Hammox.Application do
+  use Application
+
+  def start(_, _) do
+    children = [Hammox.Cache]
+    Supervisor.start_link(children, name: Hammox.Supervisor, strategy: :one_for_one)
+  end
+end

--- a/lib/hammox/cache.ex
+++ b/lib/hammox/cache.ex
@@ -1,0 +1,15 @@
+defmodule Hammox.Cache do
+  use Agent
+
+  def start_link(_initial_value) do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def put(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def get(key) do
+    Agent.get(__MODULE__, &Map.get(&1, key))
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Hammox.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Hammox.Application, []}
     ]
   end
 


### PR DESCRIPTION
Related to #47 

Adds a first version of a Cache server and uses it to cache types in memory so that they don't need to be read from disk every time.