### PR TITLE
Type-check stubs

### DIFF
--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1228,17 +1228,17 @@ defmodule HammoxTest do
   end
 
   defp assert_pass(function_name, value) do
-    TestMock |> expect(function_name, fn -> value end)
+    TestMock |> stub(function_name, fn -> value end)
     assert value == apply(TestMock, function_name, [])
   end
 
   defp assert_fail(function_name, value) do
-    TestMock |> expect(function_name, fn -> value end)
+    TestMock |> stub(function_name, fn -> value end)
     assert_raise(Hammox.TypeMatchError, fn -> apply(TestMock, function_name, []) end)
   end
 
   defp assert_fail(function_name, value, expected_message) do
-    TestMock |> expect(function_name, fn -> value end)
+    TestMock |> stub(function_name, fn -> value end)
 
     assert_raise(Hammox.TypeMatchError, expected_message, fn ->
       apply(TestMock, function_name, [])

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1227,18 +1227,32 @@ defmodule HammoxTest do
     end
   end
 
+  describe "expect/4" do
+    test "protects mocks" do
+      TestMock |> expect(:foo_none, fn -> :baz end)
+      assert_raise(Hammox.TypeMatchError, fn -> TestMock.foo_none() end)
+    end
+  end
+
+  describe "stub/3" do
+    test "protects stubs" do
+      TestMock |> stub(:foo_none, fn -> :baz end)
+      assert_raise(Hammox.TypeMatchError, fn -> TestMock.foo_none() end)
+    end
+  end
+
   defp assert_pass(function_name, value) do
-    TestMock |> stub(function_name, fn -> value end)
+    TestMock |> expect(function_name, fn -> value end)
     assert value == apply(TestMock, function_name, [])
   end
 
   defp assert_fail(function_name, value) do
-    TestMock |> stub(function_name, fn -> value end)
+    TestMock |> expect(function_name, fn -> value end)
     assert_raise(Hammox.TypeMatchError, fn -> apply(TestMock, function_name, []) end)
   end
 
   defp assert_fail(function_name, value, expected_message) do
-    TestMock |> stub(function_name, fn -> value end)
+    TestMock |> expect(function_name, fn -> value end)
 
     assert_raise(Hammox.TypeMatchError, expected_message, fn ->
       apply(TestMock, function_name, [])


### PR DESCRIPTION
Part of #56

Currently, only mocks created with `expect` are type-checked by Hammox.

This provides the same protection for stubs created with `stub`.

There is also `stub_with`, but I'm not sure how to add protection for that one; suggestions welcome!

I wasn't sure how best to test this change. For now, I modified `assert_pass` and `assert_fail` to use `stub` instead of `expect`; there are a few other tests that continue to use `expect`, so both code paths are being tested.  I'm happy to change this up however you'd like.

I extracted a helper named `wrap` that is now used in both `expect` and `stub`; I'd rather use the name `protected` for this, but that name's already taken. Again, I'm happy to change this however you'd like.