### PR TITLE
run workflow on Elixir 1.7

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: elixir:1.9.1-slim
+      image: elixir:1.7-slim
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This is the lowest supported version so we should check against it.