### PR TITLE
raise if Hammox.Protect used on module with no callbacks

### DIFF
--- a/lib/hammox/protect.ex
+++ b/lib/hammox/protect.ex
@@ -89,7 +89,15 @@ defmodule Hammox.Protect do
         """
     end
 
-    funs = Keyword.get_lazy(opts, :funs, fn -> get_funs!(behaviour || module) end)
+    module_with_callbacks = behaviour || module
+
+    funs = Keyword.get_lazy(opts, :funs, fn -> get_funs!(module_with_callbacks) end)
+
+    if funs == [] do
+      raise ArgumentError,
+        message:
+          "The module #{inspect(module_with_callbacks)} does not contain any callbacks. Please use a behaviour with at least one callback."
+    end
 
     {module, behaviour, funs}
   end

--- a/test/hammox/protect_test.exs
+++ b/test/hammox/protect_test.exs
@@ -22,6 +22,34 @@ defmodule Hammox.ProtectTest do
     end
   end
 
+  test "using Protect on a module without callbacks throws an exception" do
+    module_string = """
+    defmodule ProtectNoCallbacks do
+      use Hammox.Protect, module: Hammox.Test.Protect.Implementation
+    end
+    """
+
+    assert_raise ArgumentError,
+                 ~r/The module Hammox.Test.Protect.Implementation does not contain any callbacks./,
+                 fn ->
+                   Code.compile_string(module_string)
+                 end
+  end
+
+  test "using Protect on a behaviour without callbacks throws an exception" do
+    module_string = """
+    defmodule ProtectNoCallbacks do
+      use Hammox.Protect, module: Hammox.Test.Protect.Implementation, behaviour: Hammox.Test.Protect.EmptyBehaviour
+    end
+    """
+
+    assert_raise ArgumentError,
+                 ~r/The module Hammox.Test.Protect.EmptyBehaviour does not contain any callbacks./,
+                 fn ->
+                   Code.compile_string(module_string)
+                 end
+  end
+
   test "using Protect creates protected versions of functions from given behaviour-implementation module" do
     assert_raise Hammox.TypeMatchError, fn -> behaviour_implementation_wrong_typespec() end
   end

--- a/test/support/protect/empty_behaviour.ex
+++ b/test/support/protect/empty_behaviour.ex
@@ -1,0 +1,3 @@
+defmodule Hammox.Test.Protect.EmptyBehaviour do
+  @moduledoc false
+end


### PR DESCRIPTION
Using Hammox.Protect on a module without callbacks results in a no-op. This is
most likely due to a mistake, and we should raise in this scenario.

`Hammox.protect/3` and friends can still be used on a module without callbacks
and will return an empty map.
