### PR TITLE
Extend `protect/2` to accept a list of behviour modules

### DIFF
--- a/test/hammox/protect_test.exs
+++ b/test/hammox/protect_test.exs
@@ -57,4 +57,45 @@ defmodule Hammox.ProtectTest do
   test "using Protect creates protected versions of functions from given behaviour and implementation" do
     assert_raise Hammox.TypeMatchError, fn -> behaviour_wrong_typespec() end
   end
+
+  defmodule MultiProtect do
+    use Hammox.Protect,
+      module: Hammox.Test.MultiBehaviourImplementation,
+      behaviour: Hammox.Test.SmallBehaviour,
+      behaviour: Hammox.Test.AdditionalBehaviour
+  end
+
+  test "using Protect with multiple behaviour opts creates expected functions" do
+    # Hammox.Test.SmallBehaviour
+    assert_raise Hammox.TypeMatchError, fn -> MultiProtect.foo() end
+    assert 1 == MultiProtect.other_foo()
+    assert 1 == MultiProtect.other_foo(10)
+
+    # Hammox.Test.AdditionalBehaviour
+    assert 1 == MultiProtect.additional_foo()
+  end
+
+  defmodule MultiProtectWithFuns do
+    use Hammox.Protect,
+      module: Hammox.Test.MultiBehaviourImplementation,
+      behaviour: Hammox.Test.SmallBehaviour,
+      funs: [other_foo: 1],
+      behaviour: Hammox.Test.AdditionalBehaviour
+  end
+
+  test "using Protect with multiple behaviour / funs opts creates expected functions" do
+    # Hammox.Test.SmallBehaviour
+    assert_raise UndefinedFunctionError,
+                 ~r[MultiProtectWithFuns.foo/0 is undefined or private],
+                 fn -> apply(MultiProtectWithFuns, :foo, []) end
+
+    assert_raise UndefinedFunctionError,
+                 ~r[MultiProtectWithFuns.other_foo/0 is undefined or private],
+                 fn -> apply(MultiProtectWithFuns, :other_foo, []) end
+
+    assert 1 == MultiProtectWithFuns.other_foo(10)
+
+    # Hammox.Test.AdditionalBehaviour
+    assert 1 == MultiProtectWithFuns.additional_foo()
+  end
 end

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -71,6 +71,14 @@ defmodule HammoxTest do
       assert %{foo_0: _, other_foo_0: _, other_foo_1: _} =
                Hammox.protect(Hammox.Test.SmallImplementation, Hammox.Test.SmallBehaviour)
     end
+
+    test "decorate all functions from multiple behaviours" do
+      assert %{foo_0: _, other_foo_0: _, other_foo_1: _, additional_foo_0: _} =
+               Hammox.protect(Hammox.Test.MultiBehaviourImplementation, [
+                 Hammox.Test.SmallBehaviour,
+                 Hammox.Test.AdditionalBehaviour
+               ])
+    end
   end
 
   describe "protect/3" do

--- a/test/support/additional_behaviour.ex
+++ b/test/support/additional_behaviour.ex
@@ -1,0 +1,5 @@
+defmodule Hammox.Test.AdditionalBehaviour do
+  @moduledoc false
+
+  @callback additional_foo() :: number()
+end

--- a/test/support/multi_behaviour_implementation.ex
+++ b/test/support/multi_behaviour_implementation.ex
@@ -1,0 +1,20 @@
+defmodule Hammox.Test.MultiBehaviourImplementation do
+  @moduledoc false
+
+  @behaviour Hammox.Test.SmallBehaviour
+  @behaviour Hammox.Test.AdditionalBehaviour
+
+  @impl Hammox.Test.SmallBehaviour
+  def foo, do: :bar
+
+  @impl Hammox.Test.SmallBehaviour
+  def other_foo, do: 1
+
+  @impl Hammox.Test.SmallBehaviour
+  def other_foo(_), do: 1
+
+  @impl Hammox.Test.AdditionalBehaviour
+  def additional_foo(), do: 1
+
+  def nospec_fun, do: 1
+end


### PR DESCRIPTION
My team loves Hammox since it was recommended to us by Jose - and we really
appreciate all of the work you have put into it!

We often write modules that implement multiple behaviours and have gotten into
the habit of doing something similar to this in many of our tests

```
  setup_all do
    Map.merge(
      Hammox.protect(My.Module, My.Module.Contract),
      Hammox.protect(My.Module, My.Module.OtherContract)
    )
  end
```

This PR extends the api to `Hammox.protect` to be able to take in an
implementation module and a list of behaviours so that we could replace the
above with

```
  setup_all do
    Hammox.protect(My.Module, [My.Module.Contract, My.Module.OtherContract]),
  end
```

Please let me know if you have ideas of alternative implementations for this,
or if this does not fit with your design, feel free to disregard!

Once again - thanks for all of your work on this library - it has been very
valuable to our application!
