### PR TITLE
Update utils.ex

### DIFF
--- a/lib/hammox/utils.ex
+++ b/lib/hammox/utils.ex
@@ -40,14 +40,6 @@ defmodule Hammox.Utils do
   end
 
   def check_module_exists(module) do
-    case Code.ensure_compiled(module) do
-      {:module, _} ->
-        true
-
-      _ ->
-        raise(ArgumentError,
-          message: "Could not find module #{module_to_string(module)}."
-        )
-    end
+    Code.ensure_compiled!(module)
   end
 end


### PR DESCRIPTION
The [docs for ensure_compiled](https://hexdocs.pm/elixir/1.13/Code.html#ensure_compiled/1) specifically warn against doing this. To quote:

> If the module being checked is currently in a compiler deadlock, this function returns {:error, :unavailable}. Unavailable doesn't necessarily mean the module doesn't exist, just that it is not currently available, but it (or may not) become available in the future.
Therefore, if you can only continue if the module is available, use ensure_compiled!/1 instead. In particular, do not do this:


```elixir
case Code.ensure_compiled(module) do
  {:module, _} -> module
  {:error, _} -> raise ...
end
```

What do you think about using [`ensure_compiled!`](https://hexdocs.pm/elixir/1.13/Code.html#ensure_compiled!/1) instead? 