### PR TITLE
fix support for multiline typespecs

### DIFF
--- a/lib/hammox/type_match_error.ex
+++ b/lib/hammox/type_match_error.ex
@@ -153,6 +153,9 @@ defmodule Hammox.TypeMatchError do
     {:foo, type, []}
     |> Code.Typespec.type_to_quoted()
     |> Macro.to_string()
+    |> String.split("\n")
+    |> Enum.map(&String.replace(&1, ~r/ +/, " "))
+    |> Enum.join()
     |> String.split(" :: ")
     |> case do
       [_, type_string] -> type_string


### PR DESCRIPTION
Fixes #99.

In a recent version, Elixir started exposing the fact that some typespecs can
span multiple lines via its AST, or functions that produce typespec AST. This
caused slightly hacky string splitting within Hammox to fail, producing a
CaseClauseError when trying to print a typespec in an error message.

This is now fixed by properly accounting for the case where typespec strings
can have newlines in them.
