### PR TITLE
fix `bool()` support

### DIFF
--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -511,6 +511,10 @@ defmodule Hammox.TypeEngine do
     match_type(value, {:type, 0, :binary, [{:integer, 0, 0}, {:integer, 0, 1}]})
   end
 
+  def match_type(value, {:type, _, :bool, []}) do
+    match_type(value, {:type, 0, :boolean, []})
+  end
+
   def match_type(value, {:type, _, :boolean, []}) do
     match_type(value, {:type, 0, :union, [{:atom, 0, true}, {:atom, 0, false}]})
   end

--- a/test/hammox/protect_test.exs
+++ b/test/hammox/protect_test.exs
@@ -87,11 +87,11 @@ defmodule Hammox.ProtectTest do
     # Hammox.Test.SmallBehaviour
     assert_raise UndefinedFunctionError,
                  ~r[MultiProtectWithFuns.foo/0 is undefined or private],
-                 fn -> apply(MultiProtectWithFuns, :foo, []) end
+                 &MultiProtectWithFuns.foo/0
 
     assert_raise UndefinedFunctionError,
                  ~r[MultiProtectWithFuns.other_foo/0 is undefined or private],
-                 fn -> apply(MultiProtectWithFuns, :other_foo, []) end
+                 &MultiProtectWithFuns.other_foo/0
 
     assert 1 == MultiProtectWithFuns.other_foo(10)
 

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -783,6 +783,20 @@ defmodule HammoxTest do
     end
   end
 
+  describe "bool()" do
+    test "pass true" do
+      assert_pass(:foo_bool, true)
+    end
+
+    test "pass false" do
+      assert_pass(:foo_bool, false)
+    end
+
+    test "fail nil" do
+      assert_fail(:foo_bool, nil)
+    end
+  end
+
   describe "boolean()" do
     test "pass true" do
       assert_pass(:foo_boolean, true)

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -63,6 +63,7 @@ defmodule Hammox.Test.Behaviour do
   @callback foo_as_boolean() :: as_boolean(:ok | nil)
   @callback foo_binary() :: binary()
   @callback foo_bitstring() :: bitstring()
+  @callback foo_bool() :: bool()
   @callback foo_boolean() :: boolean()
   @callback foo_byte() :: byte()
   @callback foo_char() :: char()

--- a/test/support/multi_behaviour_implementation.ex
+++ b/test/support/multi_behaviour_implementation.ex
@@ -14,7 +14,7 @@ defmodule Hammox.Test.MultiBehaviourImplementation do
   def other_foo(_), do: 1
 
   @impl Hammox.Test.AdditionalBehaviour
-  def additional_foo(), do: 1
+  def additional_foo, do: 1
 
   def nospec_fun, do: 1
 end


### PR DESCRIPTION
Fixes #108.

Only `boolean()` was supported before. `bool()` is valid too.
