### PR TITLE
add support for type guards

### DIFF
--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1292,6 +1292,18 @@ defmodule HammoxTest do
     end
   end
 
+  describe "guarded functions" do
+    test "pass" do
+      TestMock |> expect(:foo_guarded, fn arg -> [arg] end)
+      assert [1] == TestMock.foo_guarded(1)
+    end
+
+    test "fail" do
+      TestMock |> expect(:foo_guarded, fn _ -> 1 end)
+      assert_raise(Hammox.TypeMatchError, fn -> TestMock.foo_guarded(1) end)
+    end
+  end
+
   describe "expect/4" do
     test "protects mocks" do
       TestMock |> expect(:foo_none, fn -> :baz end)

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -132,4 +132,6 @@ defmodule Hammox.Test.Behaviour do
 
   @opaque opaque_type :: :opaque_value
   @callback foo_opaque_type() :: opaque_type
+
+  @callback foo_guarded(arg) :: [arg] when arg: integer()
 end


### PR DESCRIPTION
Fixes #83.

Adds support for type guards by transforming bounded functions into regular
functions with annotated types for type checking purposes.
