### PR TITLE
Add deny/3

### DIFF
--- a/guides/Telemetry.md
+++ b/guides/Telemetry.md
@@ -40,6 +40,11 @@
   - `[:hammox, :verify_on_exit!, :start]`
     - metadata:
       - `context`: Context passed into `verify_on_exit!` setup function
+  - `[:hammox, :deny, :start]`
+    - metadata:
+      - `mock`: Name of the mock/behaviour
+      - `function_name`: Name of the function that is being mocked
+      - `arity`: The arity of the function
 
 ## Stop Events
   - `[:hammox, :expect, :stop]`
@@ -66,6 +71,11 @@
     - metadata: none
   -  `[:hammox, :verify_on_exit!, :stop]`
     - metadata: none
+  - `[:hammox, :deny, :stop]`
+    - metadata:
+      - `mock`: Name of the mock/behaviour
+      - `func`: Name of the function that is being mocked
+      - `arity`: The arity of the function
 
 ## Exception Events
   - `[:hammox, :expect, :exception]`
@@ -88,6 +98,8 @@
     - metadata: none
   -  `[:hammox, :verify_on_exit!, :exception]`
     - metadata: none
+  - `[:hammox, :deny, :exception]`
+    - metadata: none
 
 ## Example Code
   All supported events can be generated and attached to with the following code:
@@ -103,7 +115,8 @@
           :fetch_typespecs,
           :cache_put,
           :stub,
-          :verify_on_exit!
+          :verify_on_exit!,
+          :deny
         ]
 
         Enum.map(event_list, fn event ->

--- a/lib/hammox.ex
+++ b/lib/hammox.ex
@@ -58,6 +58,20 @@ defmodule Hammox do
   end
 
   @doc """
+  See [Mox.deny/3](https://hexdocs.pm/mox/Mox.html#deny/3).
+  """
+  def deny(mock, function_name, arity) do
+    Telemetry.span(
+      [:hammox, :deny],
+      %{mock: mock, function_name: function_name, arity: arity},
+      fn ->
+        result = Mox.deny(mock, function_name, arity)
+        {result, %{}}
+      end
+    )
+  end
+
+  @doc """
   See [Mox.stub/3](https://hexdocs.pm/mox/Mox.html#stub/3).
   """
   def stub(mock, function_name, code) do

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Hammox.MixProject do
 
   defp deps do
     [
-      {:mox, "~> 1.0"},
+      {:mox, "~> 1.2"},
       {:ordinal, "~> 0.1"},
       {:telemetry, "~> 1.0"},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},


### PR DESCRIPTION
Mirror new function in Mox (see https://github.com/dashbitco/mox/pull/146). Bump minimimum Mox version to ~> 1.2 since the function is included from the 1.2.0 release onwards.