### PR TITLE
add missing 'Telemetry' guide

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,8 +61,10 @@ defmodule Hammox.MixProject do
   defp docs do
     [
       extras: [
-        LICENSE: [title: "License"],
-        "README.md": [title: "Overview"]
+        "README.md": [title: "Overview"],
+        "guides/Telemetry.md": [title: "Telemetry"],
+        LICENSE: [title: "License"]
+
       ],
       main: "readme",
       source_url: @source_url,


### PR DESCRIPTION
The link from the doc to the [telemetry guide](https://hexdocs.pm/hammox/Telemetry.html) is broken because the guide is missing in the mix configuration of the doc.

It is added in the `extra` section to fix it and the order is changed to leave License last.