### PR TITLE
Fix Elixir 1.17 compilation warning

### DIFF
--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -313,7 +313,7 @@ defmodule Hammox.TypeEngine do
   end
 
   def match_type(value, {:type, _, :range, [{:integer, _, low}, {:integer, _, high}]})
-      when value in low..high do
+      when value in low..high//1 do
     :ok
   end
 


### PR DESCRIPTION
Changelog for Elixir v1.16
> ### [4. Hard deprecations](https://github.com/elixir-lang/elixir/blob/v1.16/CHANGELOG.md#4-hard-deprecations)
> #### Elixir
>  * [String] Deprecate passing a range with negative step on `String.slice/2`, give `first..last//1` instead

which caused the following compilation WARNING:
```
warning: low..high inside guards requires an explicit step, please write low..high//1 or low..high//-1 instead
  lib/hammox/type_engine.ex:316: Hammox.TypeEngine.match_type/2
```