### PR TITLE
Add support for record specs

### DIFF
--- a/lib/hammox/type_match_error.ex
+++ b/lib/hammox/type_match_error.ex
@@ -129,15 +129,20 @@ defmodule Hammox.TypeMatchError do
   defp type_to_string(type) do
     # We really want to access Code.Typespec.typespec_to_quoted/1 here but it's
     # private... this hack needs to suffice.
-    {:foo, type, []}
-    |> Code.Typespec.type_to_quoted()
-    |> Macro.to_string()
-    |> String.split("\n")
-    |> Enum.map_join(&String.replace(&1, ~r/ +/, " "))
-    |> String.split(" :: ")
-    |> case do
-      [_, type_string] -> type_string
-      [_, type_name, type_string] -> "#{type_string} (\"#{type_name}\")"
+    {:"::", _meta, [_name, quoted_type]} = Code.Typespec.type_to_quoted({:foo, type, []})
+
+    case quoted_type do
+      {:"::", _meta, [quoted_name, quoted_type]} ->
+        "#{quoted_to_string(quoted_type)} (\"#{quoted_to_string(quoted_name)}\")"
+
+      quoted_type ->
+        quoted_to_string(quoted_type)
     end
+  end
+
+  defp quoted_to_string(quoted) do
+    quoted
+    |> Macro.to_string()
+    |> String.replace(~r/\s+/, " ")
   end
 end

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -2,6 +2,7 @@ defmodule HammoxTest do
   use ExUnit.Case, async: true
 
   import Hammox
+  import Hammox.Test.Behaviour, only: [foo_record: 0, foo_record: 1]
 
   defmock(TestMock, for: Hammox.Test.Behaviour)
 
@@ -166,6 +167,20 @@ defmodule HammoxTest do
 
     test "fail" do
       assert_fail(:foo_port, :baz)
+    end
+  end
+
+  describe "record(:foo_record)" do
+    test "pass" do
+      assert_pass(:foo_record, foo_record())
+    end
+
+    test "fail non-tuple" do
+      assert_fail(:foo_record, %{atom: :ok, list: ["ok"]})
+    end
+
+    test "fail non-record" do
+      assert_fail(:foo_record, {:foo_record, :ok})
     end
   end
 
@@ -726,6 +741,20 @@ defmodule HammoxTest do
 
     test "pass" do
       assert_pass(:foo_two_tuple_literal, {:ok, :details})
+    end
+  end
+
+  describe "record fields" do
+    test "pass" do
+      assert_pass(:foo_specific_record, foo_record(atom: :ok, list: ["a", "b", "c"]))
+    end
+
+    test "fail child type" do
+      assert_fail(:foo_specific_record, foo_record(atom: "ok", list: ["a", "b", "c"]))
+    end
+
+    test "fail overall type" do
+      assert_fail(:foo_specific_record, {:another_record, :ok, ["a", "b", "c"]})
     end
   end
 

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -1,5 +1,8 @@
 defmodule Hammox.Test.Behaviour do
   @moduledoc false
+  require Record
+
+  Record.defrecord(:foo_record, atom: nil, list: [])
 
   @callback foo_any() :: any()
   @callback foo_none() :: none()
@@ -7,6 +10,7 @@ defmodule Hammox.Test.Behaviour do
   @callback foo_map() :: map()
   @callback foo_pid() :: pid()
   @callback foo_port() :: port()
+  @callback foo_record() :: record(:foo_record)
   @callback foo_reference() :: reference()
   @callback foo_struct() :: struct()
   @callback foo_tuple() :: tuple()
@@ -26,7 +30,7 @@ defmodule Hammox.Test.Behaviour do
   @callback foo_bitstring_size_literal() :: <<_::3>>
   @callback foo_bitstring_unit_literal() :: <<_::_*3>>
   @callback foo_bitstring_size_unit_literal() :: <<_::2, _::_*3>>
-  @callback foo_nullary_function_literal() :: (() -> :ok)
+  @callback foo_nullary_function_literal() :: (-> :ok)
   @callback foo_binary_function_literal() :: (:a, :b -> :ok)
   @callback foo_any_arity_function_literal() :: (... -> :ok)
   @callback foo_integer_literal() :: 1
@@ -57,6 +61,7 @@ defmodule Hammox.Test.Behaviour do
   @callback foo_struct_fields_literal() :: %Hammox.Test.Struct{foo: number()}
   @callback foo_empty_tuple_literal() :: {}
   @callback foo_two_tuple_literal() :: {:ok, atom()}
+  @callback foo_specific_record() :: record(:foo_record, atom: atom(), list: list(binary()))
 
   @callback foo_term() :: term()
   @callback foo_arity() :: arity()


### PR DESCRIPTION
[Records](https://hexdocs.pm/elixir/Record.html) are a specialized tuple, and they have a typespec format that closely resembles that of tuples. They are not used frequently in Elixir, where structs are preferred, but they still come up. Notably, `MapSet.t/1` builds upon [:sets.set/1](https://github.com/erlang/otp/blob/OTP-27.2.4/lib/stdlib/src/sets.erl#L163), which is a union of an old record-based type and a new map-based type. Even though `MapSet` always uses the map-based implementation under the hood, the typespec includes record typespecs. This is the underlying cause of #146 and #147.

Support for records requires two minor changes:
- **Match on records in TypeEngine.** The type structure for records is the same as that of tuples, so we can just copy the tuple clauses and repurpose them for records.
- **Handle named elements in TypeMatchError.** The existing `type_to_string/1` assumes there will be at most one name in the spec and that it will be at the top level (for named args). Record typespecs, however, provide a name for each field. This PR preserves the existing format for named args but also allows named components within specs.