### PR TITLE
modernize code idioms

### DIFF
--- a/lib/hammox.ex
+++ b/lib/hammox.ex
@@ -329,7 +329,12 @@ defmodule Hammox do
     end
   end
 
-  for arity <- 0..9 do
+  # The BEAM limits functions to 255 arguments, and the two variables
+  # captured by the wrapper fun (code, typespecs) count against that
+  # limit, so 253 is the highest arity we can generate.
+  @max_protect_arity 253
+
+  for arity <- 0..@max_protect_arity do
     args = Macro.generate_arguments(arity, __MODULE__)
 
     defp protected(code, typespecs, unquote(arity)) do
@@ -339,8 +344,9 @@ defmodule Hammox do
     end
   end
 
-  defp protected(_code, _typespec, arity) when arity > 9 do
-    raise "Hammox only supports protecting functions with arity up to 9. Why do you need over 9 parameters anyway?"
+  defp protected(_code, _typespec, arity) when arity > @max_protect_arity do
+    raise "Hammox cannot protect functions with arity above #{@max_protect_arity}. The BEAM " <>
+            "limits functions to 255 arguments and the protecting wrapper needs two of them."
   end
 
   defp protected_code(code, typespecs, args) do

--- a/lib/hammox.ex
+++ b/lib/hammox.ex
@@ -460,7 +460,7 @@ defmodule Hammox do
     Telemetry.span([:hammox, :match_args], %{}, fn ->
       result =
         args
-        |> Enum.zip(0..(length(args) - 1))
+        |> Enum.with_index()
         |> Enum.map(fn {arg, index} ->
           arg_type = arg_typespec(typespec, index)
 

--- a/lib/hammox.ex
+++ b/lib/hammox.ex
@@ -329,63 +329,13 @@ defmodule Hammox do
     end
   end
 
-  defp protected(code, typespecs, 0) do
-    fn ->
-      protected_code(code, typespecs, [])
-    end
-  end
+  for arity <- 0..9 do
+    args = Macro.generate_arguments(arity, __MODULE__)
 
-  defp protected(code, typespecs, 1) do
-    fn arg1 ->
-      protected_code(code, typespecs, [arg1])
-    end
-  end
-
-  defp protected(code, typespecs, 2) do
-    fn arg1, arg2 ->
-      protected_code(code, typespecs, [arg1, arg2])
-    end
-  end
-
-  defp protected(code, typespecs, 3) do
-    fn arg1, arg2, arg3 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3])
-    end
-  end
-
-  defp protected(code, typespecs, 4) do
-    fn arg1, arg2, arg3, arg4 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4])
-    end
-  end
-
-  defp protected(code, typespecs, 5) do
-    fn arg1, arg2, arg3, arg4, arg5 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4, arg5])
-    end
-  end
-
-  defp protected(code, typespecs, 6) do
-    fn arg1, arg2, arg3, arg4, arg5, arg6 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4, arg5, arg6])
-    end
-  end
-
-  defp protected(code, typespecs, 7) do
-    fn arg1, arg2, arg3, arg4, arg5, arg6, arg7 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4, arg5, arg6, arg7])
-    end
-  end
-
-  defp protected(code, typespecs, 8) do
-    fn arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8])
-    end
-  end
-
-  defp protected(code, typespecs, 9) do
-    fn arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ->
-      protected_code(code, typespecs, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9])
+    defp protected(code, typespecs, unquote(arity)) do
+      fn unquote_splicing(args) ->
+        protected_code(code, typespecs, unquote(args))
+      end
     end
   end
 

--- a/lib/hammox.ex
+++ b/lib/hammox.ex
@@ -314,7 +314,7 @@ defmodule Hammox do
         {key, value}
       end)
     end)
-    |> Enum.into(%{})
+    |> Map.new()
   end
 
   defp wrap(mock, name, code) do
@@ -502,12 +502,10 @@ defmodule Hammox do
           [{:type, _, :fun, [{:type, _, :product, args}, return_value]}, constraints]}
        ) do
     type_lookup_map =
-      constraints
-      |> Enum.map(fn {:type, _, :constraint,
-                      [{:atom, _, :is_subtype}, [{:var, _, var_name}, type]]} ->
+      Map.new(constraints, fn {:type, _, :constraint,
+                               [{:atom, _, :is_subtype}, [{:var, _, var_name}, type]]} ->
         {var_name, type}
       end)
-      |> Enum.into(%{})
 
     new_args =
       Enum.map(

--- a/lib/hammox/telemetry.ex
+++ b/lib/hammox/telemetry.ex
@@ -51,8 +51,6 @@ defmodule Hammox.Telemetry do
   @behaviour Hammox.Telemetry.Behaviour
   @impl Hammox.Telemetry.Behaviour
   def span(telemetry_tags, telemetry_metadata, func_to_wrap) do
-    # telemetry_module().span(telemetry_tags, telemetry_metadata, func_to_wrap)
-    tm = telemetry_module()
-    tm.span(telemetry_tags, telemetry_metadata, func_to_wrap)
+    telemetry_module().span(telemetry_tags, telemetry_metadata, func_to_wrap)
   end
 end

--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -82,10 +82,6 @@ defmodule Hammox.TypeEngine do
     type_mismatch(value, type)
   end
 
-  def match_type(value, {:remote_type, 0, [{:atom, 0, :elixir}, {:atom, 0, :struct}, []]} = type) do
-    if Map.has_key?(value, :__struct__), do: :ok, else: type_mismatch(value, type)
-  end
-
   def match_type(value, {:type, _, :tuple, :any}) when is_tuple(value) do
     :ok
   end

--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -97,9 +97,11 @@ defmodule Hammox.TypeEngine do
   def match_type(value, {:type, _, :tuple, tuple_types})
       when is_tuple(value) and tuple_size(value) == length(tuple_types) do
     error =
-      [Tuple.to_list(value), tuple_types, 0..(tuple_size(value) - 1)//1]
-      |> Enum.zip()
-      |> Enum.find_value(fn {elem, elem_type, index} ->
+      value
+      |> Tuple.to_list()
+      |> Enum.zip(tuple_types)
+      |> Enum.with_index()
+      |> Enum.find_value(fn {{elem, elem_type}, index} ->
         case match_type(elem, elem_type) do
           :ok ->
             nil
@@ -119,9 +121,11 @@ defmodule Hammox.TypeEngine do
   def match_type(value, {:type, _, :record, record_types})
       when is_tuple(value) and tuple_size(value) == length(record_types) do
     error =
-      [Tuple.to_list(value), record_types, 0..(tuple_size(value) - 1)]
-      |> Enum.zip()
-      |> Enum.find_value(fn {elem, elem_type, index} ->
+      value
+      |> Tuple.to_list()
+      |> Enum.zip(record_types)
+      |> Enum.with_index()
+      |> Enum.find_value(fn {{elem, elem_type}, index} ->
         case match_type(elem, elem_type) do
           :ok ->
             nil
@@ -217,7 +221,7 @@ defmodule Hammox.TypeEngine do
   def match_type(value, {:type, _, :nonempty_list, [elem_typespec]}) when is_list(value) do
     error =
       value
-      |> Enum.zip(0..length(value))
+      |> Enum.with_index()
       |> Enum.find_value(fn {elem, index} ->
         case match_type(elem, elem_typespec) do
           {:error, reasons} ->

--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -71,10 +71,8 @@ defmodule Hammox.TypeEngine do
     type_mismatch(value, type)
   end
 
-  def match_type(
-        %{__struct__: _},
-        {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :struct}, []]}
-      ) do
+  def match_type(value, {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :struct}, []]})
+      when is_struct(value) do
     :ok
   end
 

--- a/lib/hammox/type_match_error.ex
+++ b/lib/hammox/type_match_error.ex
@@ -110,12 +110,7 @@ defmodule Hammox.TypeMatchError do
   end
 
   defp leftpad(string, level) do
-    padding =
-      for(_ <- 0..level, do: "  ")
-      |> Enum.drop(1)
-      |> Enum.join()
-
-    padding <> string
+    String.duplicate("  ", level) <> string
   end
 
   defp type_to_string({:type, _, :map_field_exact, [type1, type2]}) do

--- a/lib/hammox/type_match_error.ex
+++ b/lib/hammox/type_match_error.ex
@@ -97,7 +97,7 @@ defmodule Hammox.TypeMatchError do
 
   defp message_string(reasons) when is_list(reasons) do
     reasons
-    |> Enum.zip(0..length(reasons))
+    |> Enum.with_index()
     |> Enum.map_join("\n", fn {reason, index} ->
       reason
       |> human_reason()

--- a/lib/hammox/utils.ex
+++ b/lib/hammox/utils.ex
@@ -2,11 +2,7 @@ defmodule Hammox.Utils do
   @moduledoc false
 
   def module_to_string(module_name) do
-    module_name
-    |> Atom.to_string()
-    |> String.split(".")
-    |> Enum.drop(1)
-    |> Enum.join(".")
+    inspect(module_name)
   end
 
   def replace_user_types(type, module_name) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,10 @@ defmodule Hammox.MixProject do
     ]
   end
 
+  def cli do
+    [preferred_envs: [ci: :test]]
+  end
+
   defp aliases do
     [
       ci: [

--- a/test/hammox/protect_test.exs
+++ b/test/hammox/protect_test.exs
@@ -87,11 +87,11 @@ defmodule Hammox.ProtectTest do
     # Hammox.Test.SmallBehaviour
     assert_raise UndefinedFunctionError,
                  ~r[MultiProtectWithFuns.foo/0 is undefined or private],
-                 &MultiProtectWithFuns.foo/0
+                 Function.capture(MultiProtectWithFuns, :foo, 0)
 
     assert_raise UndefinedFunctionError,
                  ~r[MultiProtectWithFuns.other_foo/0 is undefined or private],
-                 &MultiProtectWithFuns.other_foo/0
+                 Function.capture(MultiProtectWithFuns, :other_foo, 0)
 
     assert 1 == MultiProtectWithFuns.other_foo(10)
 

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -60,6 +60,26 @@ defmodule HammoxTest do
       end)
     end
 
+    test "protects functions with arity up to 253" do
+      fun =
+        Hammox.protect(
+          {Hammox.Test.LargeArityImplementation, :foo, 253},
+          Hammox.Test.LargeArityBehaviour
+        )
+
+      assert 1 == apply(fun, List.duplicate(0, 253))
+      assert_raise(Hammox.TypeMatchError, fn -> apply(fun, List.duplicate(:atom, 253)) end)
+    end
+
+    test "throws when protecting a function with arity above 253" do
+      assert_raise(RuntimeError, ~r/arity above 253/, fn ->
+        Hammox.protect(
+          {Hammox.Test.LargeArityImplementation, :beyond_limit_foo, 254},
+          Hammox.Test.LargeArityBehaviour
+        )
+      end)
+    end
+
     test "decorate multiple functions inside behaviour-implementation module" do
       assert %{foo_0: _, other_foo_1: _} =
                Hammox.protect(Hammox.Test.BehaviourImplementation,

--- a/test/support/large_arity_behaviour.ex
+++ b/test/support/large_arity_behaviour.ex
@@ -1,0 +1,9 @@
+defmodule Hammox.Test.LargeArityBehaviour do
+  @moduledoc false
+
+  max_arity_types = List.duplicate(quote(do: number()), 253)
+  @callback foo(unquote_splicing(max_arity_types)) :: number()
+
+  beyond_limit_types = List.duplicate(quote(do: number()), 254)
+  @callback beyond_limit_foo(unquote_splicing(beyond_limit_types)) :: number()
+end

--- a/test/support/large_arity_implementation.ex
+++ b/test/support/large_arity_implementation.ex
@@ -1,0 +1,19 @@
+defmodule Hammox.Test.LargeArityImplementation do
+  @moduledoc false
+
+  @behaviour Hammox.Test.LargeArityBehaviour
+
+  max_arity_args = Enum.map(1..253, &Macro.var(:"_arg#{&1}", __MODULE__))
+
+  @impl true
+  def foo(unquote_splicing(max_arity_args)) do
+    1
+  end
+
+  beyond_limit_args = Enum.map(1..254, &Macro.var(:"_arg#{&1}", __MODULE__))
+
+  @impl true
+  def beyond_limit_foo(unquote_splicing(beyond_limit_args)) do
+    1
+  end
+end


### PR DESCRIPTION
Now that the minimum supported Elixir is 1.15, the code is updated to use
current idioms: `Enum.with_index` instead of zipping against manually built
index ranges, `Map.new` instead of `Enum.into(%{})`, the `is_struct/1` guard
for `struct()` type matching, `String.duplicate/2` for message padding, and
`inspect/1` for rendering module names in error messages, which also fixes
Erlang module names rendering as empty strings. An unreachable struct matching
clause and some commented-out code are removed.

The hand-written `protected/3` clauses are replaced with a comprehension using
`Macro.generate_arguments/2`, and the 9-arity limit on protected functions is
removed. Clauses are generated up to arity 253, the most the BEAM allows for
the wrapper fun (the 255-argument limit minus the two captured variables);
anything above raises with an explanation. New tests pin both sides of the
boundary.

As a byproduct, compile warnings on recent Elixir versions are fixed in the
Protect test by building captures of intentionally undefined functions at
runtime with `Function.capture/3`, and the `mix ci` alias now runs in the test
environment via `cli/0` so its test step works locally.