### PR TITLE
fix infinite loop on non-productive recursive types

### DIFF
--- a/lib/hammox/type_engine.ex
+++ b/lib/hammox/type_engine.ex
@@ -598,20 +598,30 @@ defmodule Hammox.TypeEngine do
   end
 
   defp do_resolve_remote_type(
-         {:remote_type, _, [{:atom, _, module_name}, {:atom, _, type_name}, args]}
+         {:remote_type, _, [{:atom, _, module_name}, {:atom, _, type_name}, args]} = remote_type
        )
        when is_atom(module_name) and is_atom(type_name) and is_list(args) do
+    with {:ok, body} <- expand_remote_type(remote_type) do
+      visited = MapSet.new([{module_name, type_name, length(args)}])
+      {:ok, break_cycles(body, visited)}
+    end
+  end
+
+  # Fetch a remote type's definition and substitute its arguments, yielding the
+  # type body with any local user types rewritten as remote references. This
+  # expands a single level only; nested references stay as remote types.
+  defp expand_remote_type(
+         {:remote_type, _, [{:atom, _, module_name}, {:atom, _, type_name}, args]}
+       ) do
     with {:ok, types} <- fetch_types(module_name),
          {:ok, {type_kind, {_name, type, vars}}} when type_kind in @type_kinds <-
            get_type(types, type_name, length(args)) do
-      resolved_type =
+      body =
         args
         |> Enum.zip(vars)
-        |> Enum.reduce(type, fn {arg, var}, resolved_type ->
-          fill_type_var(resolved_type, var, arg)
-        end)
+        |> Enum.reduce(type, fn {arg, var}, acc -> fill_type_var(acc, var, arg) end)
 
-      {:ok, Utils.replace_user_types(resolved_type, module_name)}
+      {:ok, Utils.replace_user_types(body, module_name)}
     else
       {:error, {:module_fetch_failure, _}} = error ->
         error
@@ -619,6 +629,57 @@ defmodule Hammox.TypeEngine do
       {:error, {:type_not_found, {type_name, arity}}} ->
         {:error, {:remote_type_fetch_failure, {module_name, type_name, arity}}}
     end
+  end
+
+  # A type that reaches itself through only "transparent" nodes (unions and
+  # annotations), without passing through a value-consuming constructor, is
+  # non-productive: matching it would recurse forever without ever consuming
+  # part of the value. This covers direct self-reference (`@type t :: t | ...`)
+  # as well as mutual recursion (`a :: b | ...`, `b :: a | ...`). We follow
+  # transparent references eagerly, tracking the types on the current path in
+  # `visited` (keyed by {module, name, arity}, which also bounds the walk), and
+  # replace any reference that closes a cycle with `none()`, so a surrounding
+  # union falls through to its productive members. References sitting inside a
+  # value-consuming constructor (tuple, list, map, ...) are genuine structural
+  # recursion; we leave them as lazy remote types, since matching descends into
+  # a smaller value before reaching them again.
+  defp break_cycles({:type, position, :union, members}, visited) do
+    {:type, position, :union, Enum.map(members, &break_cycles(&1, visited))}
+  end
+
+  defp break_cycles({:ann_type, position, [var, inner]}, visited) do
+    {:ann_type, position, [var, break_cycles(inner, visited)]}
+  end
+
+  defp break_cycles(
+         {:remote_type, _, [{:atom, _, module_name}, {:atom, _, type_name}, args]} = remote_type,
+         visited
+       ) do
+    key = {module_name, type_name, length(args)}
+
+    cond do
+      MapSet.member?(visited, key) ->
+        {:type, 0, :none, []}
+
+      # Protocol `t()` references are matched specially at runtime (protocol
+      # dispatch), so leave them lazy rather than inlining their definition.
+      protocol?(module_name) ->
+        remote_type
+
+      true ->
+        case expand_remote_type(remote_type) do
+          {:ok, body} -> break_cycles(body, MapSet.put(visited, key))
+          {:error, _} -> remote_type
+        end
+    end
+  end
+
+  defp break_cycles(other, _visited) do
+    other
+  end
+
+  defp protocol?(module_name) do
+    Code.ensure_loaded?(module_name) and function_exported?(module_name, :__protocol__, 1)
   end
 
   defp fill_type_var(type, var, arg) do

--- a/test/hammox_test.exs
+++ b/test/hammox_test.exs
@@ -1341,6 +1341,34 @@ defmodule HammoxTest do
     end
   end
 
+  describe "recursive types" do
+    test "structurally recursive type passes" do
+      assert_pass(:foo_recursive_tree, {:node, :leaf, {:node, :leaf, :leaf}})
+    end
+
+    test "structurally recursive type fails" do
+      assert_fail(:foo_recursive_tree, {:node, :leaf, :not_a_tree})
+    end
+
+    test "directly self-referential type passes on a productive union member" do
+      assert_pass(:foo_self_referential, 42)
+    end
+
+    test "directly self-referential type fails without looping" do
+      assert_fail(:foo_self_referential, :not_an_integer)
+    end
+
+    test "mutually recursive types pass on a productive union member" do
+      # mutual_a resolves to integer() | atom()
+      assert_pass(:foo_mutually_recursive, 42)
+      assert_pass(:foo_mutually_recursive, :an_atom)
+    end
+
+    test "mutually recursive types fail without looping" do
+      assert_fail(:foo_mutually_recursive, "neither integer nor atom")
+    end
+  end
+
   describe "guarded functions" do
     test "pass" do
       TestMock |> expect(:foo_guarded, fn arg -> [arg] end)

--- a/test/support/behaviour.ex
+++ b/test/support/behaviour.ex
@@ -131,6 +131,16 @@ defmodule Hammox.Test.Behaviour do
         }
   @callback foo_multiline_param_type() :: multiline_param_type(:arg)
 
+  @type tree :: :leaf | {:node, tree, tree}
+  @callback foo_recursive_tree() :: tree
+
+  @type self_referential :: self_referential | integer()
+  @callback foo_self_referential() :: self_referential
+
+  @type mutual_a :: mutual_b | integer()
+  @type mutual_b :: mutual_a | atom()
+  @callback foo_mutually_recursive() :: mutual_a
+
   @typep private_type :: :private_value
   @type type_including_private_type :: private_type()
   @callback foo_private_type() :: type_including_private_type()


### PR DESCRIPTION
Matching a value against a recursive type could loop forever. The problem
was confined to non-productive recursion: a type that reaches itself through
only unions and annotations, without passing through a value-consuming
constructor, so nothing shrinks the value between one visit of the type and
the next. This covered directly self-referential types such as
`@type t :: t | integer()` as well as mutually recursive pairs like
`a :: b | ...` / `b :: a | ...`. Ordinary structural recursion was always
fine, because there the recursive reference sits inside a tuple, list or map,
and matching descends into a smaller value each time around, eventually
bottoming out.

Remote type resolution now follows these transparent references eagerly while
tracking the types on the current path, keyed by module, name and arity, which
also bounds the walk. Any reference that closes a cycle is replaced with
`none()`, so a surrounding union simply falls through to its productive
members and `t :: t | integer()` ends up enforcing `integer()` instead of
hanging. References sitting inside a constructor are left as lazy remote types
exactly as before, so structural recursion keeps resolving one level at a time
and is unaffected. Protocol `t()` references are also left lazy so their
runtime dispatch is preserved rather than being inlined to their underlying
type.

This is deliberately stricter than Dialyzer, which accepts these
types and widens them to `any()`, enforcing nothing. Treating the
non-productive branch as unsatisfiable is more useful. The
resolved form is cached as usual, so the steady-state match path is unchanged;
the only cost is a slightly larger one-time resolution. Tests cover structural,
directly self-referential and mutually recursive types on both their passing
and failing branches.