### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ delete it from your list of dependencies in `mix.exs`. Then add `:hammox`:
 ```elixir
 def deps do
   [
-    {:hammox, "~> 0.7", only: :test}
+    {:hammox, "~> 1.0", only: :test}
   ]
 end
 ```

--- a/lib/hammox/protect.ex
+++ b/lib/hammox/protect.ex
@@ -37,7 +37,7 @@ defmodule Hammox.Protect do
     behaviour: Hammox.Test.AdditionalBehaviour
     # with no `funs` pt provided after `AdditionalBehaviour`, all callbacks
     # will be protected
-  ````
+  ```
   """
   alias Hammox.Utils
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Hammox.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/msz/hammox"
-  @version "0.7.1"
+  @version "1.0.0"
 
   def project do
     [


### PR DESCRIPTION
Cuts the 1.0.0 release: bumps the version in mix.exs and the README install snippet, and adds a CHANGELOG.md started at this version that follows the style of the GitHub releases and is wired into the HexDocs. Also folds in a separate fix for a long-standing unclosed doc code fence in Hammox.Protect that ex_doc only started warning about after the recent upgrade.